### PR TITLE
Use syntax highlighting and remove unnecessary go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-cryptocalc
+# cryptocalc
 ==========
 
 A program to calculate md5/sha1/sha256/sha512 based on golang
 
 Install:
 
+```shell
 $ go get -u github.com/shenyp09/cryptocalc
+```
 
-$ cd $GOPATH/src/github.com/shenyp09/cryptocalc
-
-$ go install
-
-
-Usage: cryptocal command file
+### Usage: cryptocal command file
 
 Command: md5 sha1 sha256 sha512
 
 
 e.g.
 
+```shell
 $ ./cryptocal md5 cryptocal.go
 
 MD5: e49ee397aa3400341635b4f163badc1d
+```


### PR DESCRIPTION
Per Go's documentation:

``` shell
~ ❯❯❯ go get -h                                          ⏎
usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [build flags] [packages]

Get downloads and installs the packages named by the import paths,
along with their dependencies.

...
```

Otherwise, this is just a syntax highlighting / markdown formatting change.
